### PR TITLE
Backend Match Generation and Competition deletion including matches

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible Node.js debug attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${file}",
+            "outFiles": [
+                "${workspaceRoot}/out/**/*.js"
+            ]
+        }
+    ]
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,10 +1,8 @@
-<login-component></login-component>
+<log-in></log-in>
 
 <nav>
     <a routerLink="/competitions" routerLinkActive="active">Competitions</a>        
     <a routerLink="/matches" routerLinkActive="active">Matches</a>
 </nav>
-
-<log-in></log-in>
 
 <router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,7 +24,6 @@ import { AngularFireModule } from 'angularfire2';
 import { environment } from '../environments/environment';
 
 export const routes: Routes = [
-    { path: '', component: AppComponent },
 ];
 
 

--- a/src/app/components/competition-detail/competition-detail.component.ts
+++ b/src/app/components/competition-detail/competition-detail.component.ts
@@ -19,13 +19,12 @@ export class CompetitionDetailComponent {
         private router: Router
     ) { }
 
-
     ngOnInit() {
         this.competitionId = this.route.snapshot.paramMap.get('id');
         if (this.competitionId) {
             this.competitionService.getCompetition(this.competitionId).snapshotChanges().subscribe(competition => {
                 if (competition.key) {
-                    this.competition = {id: competition.key, ...competition.payload.val()}                    
+                    this.competition = {id: competition.key, ...competition.payload.val()}
                 } else {
                     this.competition = new Competition();
                 }

--- a/src/app/components/competition-form/competition-form.component.ts
+++ b/src/app/components/competition-form/competition-form.component.ts
@@ -26,7 +26,8 @@ export class CompetitionFormComponent implements OnInit {
         this.competition.rounds = [];
         this.competition.creator = null;
         this.competition.winner = null;
-
+        this.competition.dateInMs = new Date(this.competition.date).getTime();
+        console.log(this.competition);
         if (this.competitionId) {
             this.competitionService.updateCompetition(this.competitionId, this.competition);
         } else {
@@ -45,6 +46,5 @@ export class CompetitionFormComponent implements OnInit {
                 }
             });
         }
-
     }
 }

--- a/src/app/models/Competition.ts
+++ b/src/app/models/Competition.ts
@@ -1,6 +1,6 @@
-import { User } from "./User";
-import { Match } from "./Match";
-import { Round } from "./Round";
+import { User } from "./user";
+import { Match } from "./match";
+import { Round } from "./round";
 
 export class Competition {
     id: string;
@@ -9,6 +9,7 @@ export class Competition {
     type: string;
     name: string;
     date: Date;
+    dateInMs: number;
     maxAmountOfParticipants: number;
     minutesPerMatch: number;
     creator: User;

--- a/src/app/models/Match.ts
+++ b/src/app/models/Match.ts
@@ -6,5 +6,6 @@ export class Match {
     creator: User;
     participants: User[];
     startingTime: Date;
+    startingTimeInMs: number;
     winner: User;
 }

--- a/src/app/models/Round.ts
+++ b/src/app/models/Round.ts
@@ -1,4 +1,7 @@
+import { Match } from "../models/match";
+
 export class Round {
-    id: number;
-    matches: any[];
+    id: string;
+    number: number;
+    matches: Match[];
 }

--- a/src/app/modules/competition.module.ts
+++ b/src/app/modules/competition.module.ts
@@ -4,7 +4,6 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 // models
-import { User } from "../models/user";
 import { Competition } from "../models/competition";
 
 // components
@@ -18,6 +17,8 @@ import { CompetitionUsersComponent } from '../components/competition-users/compe
 // services
 import { CompetitionService } from '../services/competition.service';
 import { UserService } from '../services/user.service';
+import { MatchService } from '../services/match.service';
+import { RoundService } from '../services/round.service';
 
 export const routes: Routes = [
     { path: 'competitions', component: CompetitionListComponent },
@@ -43,7 +44,9 @@ export const routes: Routes = [
     ],
     providers: [
         CompetitionService,
-        UserService
+        UserService,
+        MatchService,
+        RoundService
     ],
     bootstrap: [CompetitionListComponent]
 })

--- a/src/app/services/competition.service.ts
+++ b/src/app/services/competition.service.ts
@@ -1,6 +1,11 @@
 import { Injectable } from "@angular/core";
 import { AngularFireDatabase, AngularFireList, AngularFireObject } from "angularfire2/database";
+import { MatchService } from "../services/match.service";
+import { RoundService } from "../services/round.service";
 import { Competition } from "../models/Competition";
+import { Round } from "../models/round";
+import { Match } from "../models/match";
+import { User } from "../models/user";
 import { Observable } from "rxjs/Observable";
 
 
@@ -12,7 +17,10 @@ export class CompetitionService {
 
     private competitionTableName = '/competitions';
 
-    constructor(private database: AngularFireDatabase) {
+    constructor(private database: AngularFireDatabase,
+        private matchService: MatchService,
+        private roundService: RoundService
+    ) {
         this.getCompetitions();
     }
 
@@ -27,10 +35,26 @@ export class CompetitionService {
     }
 
     public deleteCompetition(key: string) {
-        this.competitions.remove(key);
+        this.getCompetition(key).valueChanges().subscribe(competition => {
+            if (competition) {
+                competition.rounds.forEach(round => {
+                    round.matches.forEach(match => {
+                        this.matchService.deleteMatch(match.id);
+                    });
+                });
+                this.competitions.remove(competition.id);
+            }
+        });
     }
 
     public createCompetition(competition: Competition) {
+        switch (competition.type) {
+            case "TOURNAMENT":
+                this.generateTournament(competition);
+                break;
+            case "POULE": break;
+            case "KNOCKOUT": break;
+        }
         var newCompetition = competition;
         newCompetition.id = null;
         this.competitions.push(newCompetition);
@@ -40,5 +64,96 @@ export class CompetitionService {
         var updatedCompetition = competition;
         updatedCompetition.id = null;
         this.competitions.update(id, updatedCompetition);
+    }
+
+    public generateTournament(competition: Competition) {
+        var rounds: Round[] = [];
+        var roundsReferences: Round[] = [];
+        for (var i = 0; i < (competition.participants.length / 2); i++) {
+            var round = new Round();
+            round.number = i;
+            round.matches = this.generateMatches(competition.participants, rounds, competition, i);
+            rounds.push(round);
+        }
+
+        rounds.forEach(round => {
+            var roundReference = new Round();
+            roundReference.matches = [];
+            round.matches.forEach(match => {
+                var ref = this.matchService.createMatch(match);
+                roundReference.matches.push({ id: ref.key } as Match);
+            });
+            roundsReferences.push(roundReference);
+        });
+        competition.rounds = roundsReferences;
+    }
+
+    public havePlayedAgainstEachOther(user1: User, user2: User, rounds: Round[]): boolean {
+        rounds.forEach(round => {
+            round.matches.forEach(match => {
+                if (match.participants.indexOf(user1) != -1 && match.participants.indexOf(user2)) {
+                    return true;
+                }
+            });
+        });
+        return false;
+    }
+
+    public havePlayedInThisRound(user1: User, user2: User, participants: User[]): boolean {
+        if (participants.indexOf(user1) != -1 || participants.indexOf(user2) != -1) {
+            return true;
+        }
+        return false;
+    }
+
+    public generateUniqueMatch(competitionParticipants: User[], rounds: Round[], competition: Competition, multiplier: number): Match {
+        var user1Index = 0;
+        var user2Index = 0;
+
+        var startingTime = new Date(competition.date);
+        startingTime.setTime(startingTime.getTime() + (competition.minutesPerMatch * multiplier) * 60 * 1000);
+        var startingTimeInMs = startingTime.getTime()
+
+        var match = new Match();
+        match.status = "OPEN";
+        match.creator = competition.creator;
+        match.startingTimeInMs = startingTimeInMs;
+        match.participants = [];
+        do {
+            var user1Index = Math.floor(Math.random() * (competitionParticipants.length));
+            var user2Index = Math.floor(Math.random() * (competitionParticipants.length));
+        } while (user1Index == user2Index);
+        var user1 = competitionParticipants[user1Index];
+        var user2 = competitionParticipants[user2Index];
+
+        if (this.havePlayedInThisRound(user1, user2, match.participants)) {
+            this.generateUniqueMatch(competitionParticipants, rounds, competition, multiplier);
+        } else {
+            match.participants.push(user1);
+            match.participants.push(user2);
+
+            if (this.havePlayedAgainstEachOther(user1, user2, rounds)) {
+                this.generateUniqueMatch(competitionParticipants, rounds, competition, multiplier);
+            } else {
+                competitionParticipants.splice(user1Index, 1);
+                competitionParticipants.splice(user2Index, 1);
+                return match;
+            }
+        }
+    }
+
+    public generateMatches(participants: User[], rounds: Round[], competition, multiplier: number): Match[] {
+        var competitionParticipants = [];
+        var matches = [];
+
+        for (var i = 0, len = participants.length; i < len; ++i) {
+            competitionParticipants[i] = participants[i];
+        }
+
+        for (var i = 0; i < participants.length / 2; i++) {
+            matches.push(this.generateUniqueMatch(competitionParticipants, rounds, competition, multiplier));
+        }
+
+        return matches;
     }
 }

--- a/src/app/services/match.service.ts
+++ b/src/app/services/match.service.ts
@@ -27,18 +27,18 @@ export class MatchService {
     }
 
     public deleteMatch(key: string) {
-        this.matches.remove(key);
+        return this.matches.remove(key);
     }
 
     public createMatch(match: Match) {
         var newMatch = match;
         newMatch.id = null;
-        this.matches.push(newMatch);
+        return this.matches.push(newMatch);
     }
 
     public updateMatch(id: string, match: Match) {
         var updatedMatch = match;
         updatedMatch.id = null;
-        this.matches.update(id, updatedMatch);
+        return this.matches.update(id, updatedMatch);
     }
 }

--- a/src/app/services/round.service.ts
+++ b/src/app/services/round.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { AngularFireDatabase } from "angularfire2/database";
+import { AngularFireDatabase, AngularFireList, AngularFireObject } from "angularfire2/database";
 import { Round } from "../models/Round";
 import { Observable } from "rxjs/Observable";
 
@@ -7,8 +7,8 @@ import { Observable } from "rxjs/Observable";
 @Injectable()
 export class RoundService {
 
-    public roundObservable: Observable<any[]>;
-    public rounds: Round[];
+    public rounds: AngularFireList<Round>;
+    public round: AngularFireObject<Round>;
 
     private roundTableName = '/rounds';
 
@@ -17,21 +17,24 @@ export class RoundService {
     }
 
     public getRounds() {
-        this.roundObservable = this.database.list(this.roundTableName).valueChanges();
-        this.roundObservable.subscribe(rounds => {
-            this.rounds = rounds as Round[];
-        });
+        this.rounds = this.database.list(this.roundTableName);
+        return this.rounds;
+    }
+
+    public getRound(id: string) {
+        this.rounds = this.database.list(this.roundTableName + "/" + id);
+        return this.rounds;
     }
 
     public deleteRound(key: string) {
-        this.database.list(this.roundTableName).remove(key);
+        return this.rounds.remove(key);
     }
 
     public createRound(round: Round) {
-        this.database.list(this.roundTableName).push(round);
+        return this.rounds.push(round);
     }
 
     public updateRound(key: string, round: Round) {
-        this.database.list(this.roundTableName).update(key, round);
+        return this.rounds.update(key, round);
     }
 }


### PR DESCRIPTION
Voor het competitietype TOURNAMENT kunnen nu matches worden gegenereerd. Het werkt wel alleen met even aantallen. Het is ook een beetje stom om met oneven aantallen een competitie te gaan spelen. Validatie zit er nog niet in.

Ook realiseer ik nu dat competition.creator (en dus match.creator) er nog niet in zit. 

Verder worden nu ook de bijhorende matches verwijderd als je een competitie verwijderd.