### PR TITLE
Tournament generation v1.2 +Poule generation v1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -955,6 +955,11 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "atoa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atoa/-/atoa-1.0.0.tgz",
+      "integrity": "sha1-DMDpGkgOc4+SPrwQNnZHF3mzSkk="
+    },
     "atob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
@@ -2114,6 +2119,15 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
+    "contra": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/contra/-/contra-1.9.4.tgz",
+      "integrity": "sha1-9TveQtfltZhcrk2ZqNYQUm3o8o0=",
+      "requires": {
+        "atoa": "1.0.0",
+        "ticky": "1.0.1"
+      }
+    },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
@@ -2274,6 +2288,21 @@
       "requires": {
         "lru-cache": "4.1.3",
         "which": "1.3.1"
+      }
+    },
+    "crossvent": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.4.tgz",
+      "integrity": "sha1-2ixPj0DJR4JRe/K+7BBEFIGUq5I=",
+      "requires": {
+        "custom-event": "1.0.0"
+      },
+      "dependencies": {
+        "custom-event": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz",
+          "integrity": "sha1-LkYovhncSyFLXAJjDFlx6BFhgGI="
+        }
       }
     },
     "cryptiles": {
@@ -2791,6 +2820,15 @@
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
       "dev": true,
       "optional": true
+    },
+    "dragula": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/dragula/-/dragula-3.7.2.tgz",
+      "integrity": "sha1-SjXJ05gf+sGpScKcpyhQWOhzk84=",
+      "requires": {
+        "contra": "1.9.4",
+        "crossvent": "1.5.4"
+      }
     },
     "duplexify": {
       "version": "3.6.0",
@@ -7470,6 +7508,14 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "ng2-dragula": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ng2-dragula/-/ng2-dragula-1.5.0.tgz",
+      "integrity": "sha512-uSVq66Rv+ZhDLBGYCGZ7mTaseP7rvYJOijiQZlzfy8dxL614Sw7rhtnLqvK8nqa3tI/wVv8CEGZaZkMnWJokwQ==",
+      "requires": {
+        "dragula": "3.7.2"
+      }
+    },
     "ngx-bootstrap": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-3.0.0.tgz",
@@ -10494,6 +10540,11 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
       "integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E=",
       "dev": true
+    },
+    "ticky": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.1.tgz",
+      "integrity": "sha1-t8+nHnaPHJAAxJe5FRswlHxQ5G0="
     },
     "time-stamp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "angularfire2": "^5.0.0-rc.6",
     "core-js": "^2.5.7",
     "firebase": "4.13.1",
+    "ng2-dragula": "^1.5.0",
     "ngx-bootstrap": "^3.0.0",
     "rxjs": "^6.2.0",
     "rxjs-compat": "^6.1.0",

--- a/src/app/components/competition-detail/competition-detail.component.html
+++ b/src/app/components/competition-detail/competition-detail.component.html
@@ -2,6 +2,8 @@
 
     <h1>Details for {{ competition.name }}</h1>
 
+    <a class="btn btn-info" routerLink="/competitions/{{competition.id}}/scheme" routerLinkActive="active">Show scheme</a>    
+    <br><br>    
     <table class="table table-sm">
         <tr>
             <th>Id</th>

--- a/src/app/components/competition-form/competition-form.component.html
+++ b/src/app/components/competition-form/competition-form.component.html
@@ -38,6 +38,36 @@
 
         </div>
 
+        <div *ngIf="competition.type == 'TOURNAMENT'" class="row">
+            <div class="col-md-12" *ngIf="competition.type == 'TOURNAMENT'">
+                <label for="numberOfRoundsInput">Number of rounds</label>
+                <input class="form-control" type="number" id="numberOfRoundsInput" name="numberOfRounds" [(ngModel)]="competition.numberOfRounds">
+            </div>
+        </div>
+
+        <div *ngIf="competition.type == 'POULE'" class="row">
+            <div class="col-md-12" *ngIf="competition.type == 'POULE'">
+                <label for="numberOfPoulesInput">Number of poules</label>
+                <input class="form-control" type="number" id="numberOfPoulesInput" name="numberOfPoules" [(ngModel)]="competition.numberOfPoules">
+            </div>
+
+            <div *ngIf="competition.numberOfPoules && competition.numberOfPoules > 0" class="col-md-12">
+                <span class="btn btn-success" (click)="generatePoules()">Generate Poules</span>
+            </div>
+
+            <div *ngIf="poules" class="col-md-12">
+                <label>Poules:</label>
+            </div>
+
+            <div class="col-md-12" *ngIf="poules">
+                <ul *ngFor="let poule of poules" class="col-md-3 list-group" [dragula]='"bag-one"' [dragulaModel]='poule'>
+                    <li class="list-group-item" *ngFor="let participant of poule.participants">
+                        <span>{{participant.id}}</span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
         <button type="submit" class="btn btn-success">Submit</button>
     </form>
 </div>

--- a/src/app/components/competition-form/competition-form.component.ts
+++ b/src/app/components/competition-form/competition-form.component.ts
@@ -4,16 +4,18 @@ import { CompetitionService } from "../../services/competition.service";
 import { UserService } from "../../services/user.service";
 import { Competition } from "../../models/competition";
 import { User } from "../../models/user";
+import { DragulaModule } from 'ng2-dragula';
 
 @Component({
     selector: 'competition-form',
     templateUrl: './competition-form.component.html',
-    styleUrls: ['./competition-form.component.scss'],
+    styleUrls: ['./competition-form.component.scss', "../../../../node_modules/dragula/dist/dragula.css"],
 })
 export class CompetitionFormComponent implements OnInit {
 
     @Input() competition: Competition = new Competition();
     private competitionId: string;
+    private poules: any[];
 
     constructor(
         private competitionService: CompetitionService,
@@ -22,12 +24,36 @@ export class CompetitionFormComponent implements OnInit {
         private router: Router
     ) { }
 
+    public generatePoules() {
+        var poules = [];
+        var playersPerPoule = this.competition.participants.length / this.competition.numberOfPoules;
+        var participants = [];
+
+        for (var i = 0; i < this.competition.participants.length; i++) {
+            participants.push(this.competition.participants[i]);
+        }
+
+        for (var i = 0; i < this.competition.numberOfPoules; i++) {
+            var pouleParticipants = [];
+            var poule: any = {};
+            for (var j = 0; j < playersPerPoule; j++) {
+                pouleParticipants.push(participants[j] as User);
+            }
+            participants.splice(participants[0], playersPerPoule)
+            poule.participants = pouleParticipants;
+            poules.push(poule);
+        }
+        this.poules = poules;
+    }
+
     onSubmit(form: any): void {
         this.competition.rounds = [];
         this.competition.creator = null;
         this.competition.winner = null;
         this.competition.dateInMs = new Date(this.competition.date).getTime();
-        console.log(this.competition);
+        if (this.competition.type == "POULE") {
+            this.competition.poules = this.poules;
+        }
         if (this.competitionId) {
             this.competitionService.updateCompetition(this.competitionId, this.competition);
         } else {

--- a/src/app/components/match-scheme/match-scheme.component.html
+++ b/src/app/components/match-scheme/match-scheme.component.html
@@ -1,0 +1,21 @@
+<div class="container">
+    <div class="row" *ngFor="let round of competition.rounds">
+        <table class="table table-striped col">
+            <thead>
+                <tr>
+                    <th>
+                        <span *ngIf="competition.type == 'TOURNAMENT'">Round:</span>
+                        <span *ngIf="competition.type == 'POULE'">Poule:</span>
+                        <span>{{round.number}}</span>
+                    </th>
+                    <th></th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let match of round.matches" match-simple [match]="match">
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/src/app/components/match-scheme/match-scheme.component.scss
+++ b/src/app/components/match-scheme/match-scheme.component.scss
@@ -1,0 +1,9 @@
+@import '../../variables.scss';
+
+table {
+    margin-top: $default-margin;
+}
+
+.btn {
+    width: $default-button-width;
+}

--- a/src/app/components/match-scheme/match-scheme.component.ts
+++ b/src/app/components/match-scheme/match-scheme.component.ts
@@ -1,0 +1,38 @@
+import { Component, OnInit } from '@angular/core';
+import { Router, ActivatedRoute, ParamMap } from '@angular/router';
+import { CompetitionService } from "../../services/competition.service";
+import { MatchService } from "../../services/match.service";
+import { Competition } from "../../models/competition";
+import { Match } from "../../models/match";
+
+@Component({
+    selector: 'match-scheme',
+    templateUrl: './match-scheme.component.html',
+    styleUrls: ['./match-scheme.component.scss'],
+    providers: [MatchService]
+})
+export class MatchSchemeComponent implements OnInit {
+
+    public competition: Competition = new Competition();
+    public competitionId: string;
+
+    constructor(
+        private matchService: MatchService,
+        private competitionService: CompetitionService,
+        private route: ActivatedRoute,
+        private router: Router
+    ) { }
+
+    ngOnInit() {
+        this.competitionId = this.route.snapshot.paramMap.get('id');
+        if (this.competitionId) {
+            this.competitionService.getCompetition(this.competitionId).snapshotChanges().subscribe(competition => {
+                if (competition.key) {
+                    this.competition = { id: competition.key, ...competition.payload.val() }
+                } else {
+                    this.competition = new Competition();
+                }
+            });
+        }
+    }
+}

--- a/src/app/components/match-simple/match-simple.component.html
+++ b/src/app/components/match-simple/match-simple.component.html
@@ -1,0 +1,3 @@
+<td *ngIf="match.participants && match.participants[0]">{{match.participants[0].name}}</td>
+<td> VS. </td>
+<td *ngIf="match.participants && match.participants[1]">{{match.participants[1].name}}</td>

--- a/src/app/components/match-simple/match-simple.component.scss
+++ b/src/app/components/match-simple/match-simple.component.scss
@@ -1,0 +1,5 @@
+@import '../../variables.scss';
+
+.table {
+    width: $competition-table-width;
+}

--- a/src/app/components/match-simple/match-simple.component.ts
+++ b/src/app/components/match-simple/match-simple.component.ts
@@ -1,0 +1,35 @@
+import { Router, ActivatedRoute, ParamMap } from '@angular/router';
+import { Component, Input } from '@angular/core';
+import { MatchService } from "../../services/match.service";
+import { UserService } from "../../services/user.service";
+import { Match } from "../../models/match";
+
+@Component({
+    selector: '[match-simple]',
+    templateUrl: './match-simple.component.html',
+    styleUrls: ['./match-simple.component.scss'],
+})
+export class MatchSimpleComponent {
+
+    @Input() match: Match = new Match();
+
+    constructor(
+        private matchService: MatchService,
+        private userService: UserService,        
+    ) { }
+
+
+    ngOnInit() {
+        if (this.match) {
+            this.matchService.getMatch(this.match.id).snapshotChanges().subscribe(match => {
+                if (match.key) {
+                    this.match = { id: match.key, ...match.payload.val() }
+                    this.match.participants = this.userService.getAllUsersForMatch(this.match);
+                } else {
+                    this.match = new Match();
+                }
+            });
+        }
+    }
+
+}

--- a/src/app/models/Competition.ts
+++ b/src/app/models/Competition.ts
@@ -5,7 +5,10 @@ import { Round } from "./round";
 export class Competition {
     id: string;
     participants: User[];
+    numberOfRounds: number;
+    numberOfPoules: number;    
     rounds: Round[];
+    poules: any[];
     type: string;
     name: string;
     date: Date;

--- a/src/app/modules/competition.module.ts
+++ b/src/app/modules/competition.module.ts
@@ -2,6 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule, Routes } from '@angular/router';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { DragulaModule } from 'ng2-dragula';
 
 // models
 import { Competition } from "../models/competition";
@@ -12,6 +13,8 @@ import { CompetitionFormComponent } from '../components/competition-form/competi
 import { CompetitionDetailComponent } from '../components/competition-detail/competition-detail.component';
 import { CompetitionUsersInputComponent } from '../components/competition-users-input/competition-users-input.component';
 import { CompetitionUsersComponent } from '../components/competition-users/competition-users.component';
+import { MatchSchemeComponent } from '../components/match-scheme/match-scheme.component';
+import { MatchSimpleComponent } from '../components/match-simple/match-simple.component';
 
 // services
 import { CompetitionService } from '../services/competition.service';
@@ -22,8 +25,9 @@ import { RoundService } from '../services/round.service';
 export const routes: Routes = [
     { path: 'competitions', component: CompetitionListComponent },
     { path: 'competitions/add', component: CompetitionFormComponent },
-    { path: 'competitions/:id', component: CompetitionDetailComponent },   
-    { path: 'competitions/:id/edit', component: CompetitionFormComponent }
+    { path: 'competitions/:id', component: CompetitionDetailComponent },
+    { path: 'competitions/:id/edit', component: CompetitionFormComponent },
+    { path: 'competitions/:id/scheme', component: MatchSchemeComponent },
 ];
 
 
@@ -33,12 +37,15 @@ export const routes: Routes = [
         CompetitionFormComponent,
         CompetitionDetailComponent,
         CompetitionUsersInputComponent,
-        CompetitionUsersComponent
+        CompetitionUsersComponent,
+        MatchSchemeComponent,
+        MatchSimpleComponent
     ],
     imports: [
         BrowserModule,
         FormsModule,
-        RouterModule.forRoot(routes)
+        RouterModule.forRoot(routes),
+        DragulaModule
     ],
     providers: [
         CompetitionService,

--- a/src/app/services/competition.service.ts
+++ b/src/app/services/competition.service.ts
@@ -42,9 +42,9 @@ export class CompetitionService {
                         this.matchService.deleteMatch(match.id);
                     });
                 });
-                this.competitions.remove(competition.id);
             }
         });
+        this.competitions.remove(key);
     }
 
     public createCompetition(competition: Competition) {
@@ -52,7 +52,9 @@ export class CompetitionService {
             case "TOURNAMENT":
                 this.generateTournament(competition);
                 break;
-            case "POULE": break;
+            case "POULE":
+                this.generatePoule(competition);
+                break;
             case "KNOCKOUT": break;
         }
         var newCompetition = competition;
@@ -66,18 +68,80 @@ export class CompetitionService {
         this.competitions.update(id, updatedCompetition);
     }
 
-    public generateTournament(competition: Competition) {
+    public calculateUniqueMatches(participants: User[]) {
+        var participantCombos = [];
+
+        for (var i = 0; i < participants.length; i++) {
+            for (var j = 0; j < participants.length; j++) {
+                var user1 = participants[i];
+                var user2 = participants[j];
+                var shouldAdd = true;
+                if (participantCombos.length != 0) {
+                    for (var k = 0; k < participantCombos.length; k++) {
+                        var participantCombo = participantCombos[k];
+                        if (this.arraysEqual(participantCombo.users, [user1.id, user2.id])) {
+                            shouldAdd = false;
+                            continue;
+                        }
+                    }
+                }
+                if (user1.id == user2.id) {
+                    shouldAdd = false;
+                }
+                if (shouldAdd) {
+                    participantCombos.push({ users: [user1.id, user2.id]/*, occurences: 0*/ })
+                }
+            }
+        }
+        return participantCombos;
+    }
+
+    public generatePoule(competition: Competition) {
         var rounds: Round[] = [];
         var roundsReferences: Round[] = [];
-        for (var i = 0; i < (competition.participants.length / 2); i++) {
+
+        for (var i = 0; i < competition.numberOfPoules; i++) {
+            var pouleParticipants: any[] = competition.poules[i].participants;
+            var participantCombos = this.calculateUniqueMatches(pouleParticipants);
+            var participantCombosCopy: any[] = [];
+
+            for (var j = 0; j < participantCombos.length; j++)
+                participantCombosCopy.push(participantCombos[j]);
+
             var round = new Round();
-            round.number = i;
-            round.matches = this.generateMatches(competition.participants, rounds, competition, i);
+            round.number = i + 1;
+            round.matches = this.generateMatches(participantCombos, participantCombosCopy, rounds, competition, i);
             rounds.push(round);
         }
 
+        //TODO: EEN SPELER MAG NIET 2X OM DEZELFDE TIJD SPELEN!!
+
+        this.createMatches(rounds, roundsReferences);
+        competition.rounds = roundsReferences;
+    }
+
+    public generateTournament(competition: Competition) {
+        var participantCombos = this.calculateUniqueMatches(competition.participants);
+        var rounds: Round[] = [];
+        var roundsReferences: Round[] = [];
+        var participantCombosCopy: any[] = [];
+        for (var i = 0; i < participantCombos.length; i++)
+            participantCombosCopy.push(participantCombos[i]);
+
+        for (var i = 0; i < competition.numberOfRounds; i++) {
+            var round = new Round();
+            round.number = i + 1;
+            round.matches = this.generateMatches(participantCombos, participantCombosCopy, rounds, competition, i);
+            rounds.push(round);
+        }
+        this.createMatches(rounds, roundsReferences);
+        competition.rounds = roundsReferences;
+    }
+
+    public createMatches(rounds: Round[], roundsReferences: Round[]) {
         rounds.forEach(round => {
             var roundReference = new Round();
+            roundReference.number = round.number;
             roundReference.matches = [];
             round.matches.forEach(match => {
                 var ref = this.matchService.createMatch(match);
@@ -85,75 +149,90 @@ export class CompetitionService {
             });
             roundsReferences.push(roundReference);
         });
-        competition.rounds = roundsReferences;
+    }
+
+    public generateMatches(participantCombosReference: any[], participantCombosPool: any[], rounds: Round[], competition: Competition, multiplier: number): Match[] {
+        var matches = [];
+        var startingTime = new Date(competition.date);
+        startingTime.setTime(startingTime.getTime() + (competition.minutesPerMatch * multiplier) * 60 * 1000);
+        var startingTimeInMs = startingTime.getTime();
+
+        for (var i = 0; i < participantCombosReference.length; i++) {
+            var match = new Match();
+            match.status = "OPEN";
+            match.creator = competition.creator;
+            match.startingTimeInMs = startingTimeInMs;
+            match.participants = [];
+
+            for (var j = 0; j < participantCombosReference[i].users.length; j++) {
+                var user1Id = participantCombosReference[i].users[0];
+                var user2Id = participantCombosReference[i].users[1];
+
+                if (matches.length < participantCombosReference.length / 2 || competition.type != "TOURNAMENT") {
+                    if (!this.havePlayedInThisRound(user1Id, user2Id, matches) || competition.type != "TOURNAMENT") {
+                        if (!this.havePlayedAgainstEachOther({ id: user1Id } as User, { id: user2Id } as User, rounds)) {
+                            if (match.participants.length < 2) {
+                                match.participants.push({ id: user1Id } as User);
+                                match.participants.push({ id: user2Id } as User);
+                                participantCombosPool.splice(participantCombosPool[i], 1)
+                                matches.push(match);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return matches;
     }
 
     public havePlayedAgainstEachOther(user1: User, user2: User, rounds: Round[]): boolean {
-        rounds.forEach(round => {
-            round.matches.forEach(match => {
-                if (match.participants.indexOf(user1) != -1 && match.participants.indexOf(user2)) {
-                    return true;
+        for (var i = 0; i < rounds.length; i++) {
+            for (var j = 0; j < rounds[i].matches.length; j++) {
+                var match = rounds[i].matches[j];
+                if (match && match.participants) {
+                    var users = match.participants;
+                    if (JSON.stringify(users) == JSON.stringify([{ id: user1.id }, { id: user2.id }])) {
+                        return true;
+                    }
+                    if (JSON.stringify(users) == JSON.stringify([{ id: user2.id }, { id: user1.id }])) {
+                        return true;
+                    }
                 }
-            });
-        });
-        return false;
-    }
-
-    public havePlayedInThisRound(user1: User, user2: User, participants: User[]): boolean {
-        if (participants.indexOf(user1) != -1 || participants.indexOf(user2) != -1) {
-            return true;
-        }
-        return false;
-    }
-
-    public generateUniqueMatch(competitionParticipants: User[], rounds: Round[], competition: Competition, multiplier: number): Match {
-        var user1Index = 0;
-        var user2Index = 0;
-
-        var startingTime = new Date(competition.date);
-        startingTime.setTime(startingTime.getTime() + (competition.minutesPerMatch * multiplier) * 60 * 1000);
-        var startingTimeInMs = startingTime.getTime()
-
-        var match = new Match();
-        match.status = "OPEN";
-        match.creator = competition.creator;
-        match.startingTimeInMs = startingTimeInMs;
-        match.participants = [];
-        do {
-            var user1Index = Math.floor(Math.random() * (competitionParticipants.length));
-            var user2Index = Math.floor(Math.random() * (competitionParticipants.length));
-        } while (user1Index == user2Index);
-        var user1 = competitionParticipants[user1Index];
-        var user2 = competitionParticipants[user2Index];
-
-        if (this.havePlayedInThisRound(user1, user2, match.participants)) {
-            this.generateUniqueMatch(competitionParticipants, rounds, competition, multiplier);
-        } else {
-            match.participants.push(user1);
-            match.participants.push(user2);
-
-            if (this.havePlayedAgainstEachOther(user1, user2, rounds)) {
-                this.generateUniqueMatch(competitionParticipants, rounds, competition, multiplier);
-            } else {
-                competitionParticipants.splice(user1Index, 1);
-                competitionParticipants.splice(user2Index, 1);
-                return match;
             }
         }
+        return false;
     }
 
-    public generateMatches(participants: User[], rounds: Round[], competition, multiplier: number): Match[] {
-        var competitionParticipants = [];
-        var matches = [];
-
-        for (var i = 0, len = participants.length; i < len; ++i) {
-            competitionParticipants[i] = participants[i];
+    public havePlayedInThisRound(user1Id: string, user2Id: string, matches: Match[]) {
+        if (matches.length > 0) {
+            for (var i = 0; i < matches.length; i++) {
+                for (var j = 0; j < matches[i].participants.length; j++) {
+                    var users = matches[i].participants;
+                    if (JSON.stringify(users).indexOf(JSON.stringify({ id: user1Id })) != -1) {
+                        return true;
+                    }
+                    if (JSON.stringify(users).indexOf(JSON.stringify({ id: user2Id })) != -1) {
+                        return true;
+                    }
+                }
+            }
         }
+        return false;
+    }
 
-        for (var i = 0; i < participants.length / 2; i++) {
-            matches.push(this.generateUniqueMatch(competitionParticipants, rounds, competition, multiplier));
+    public arraysEqual(_arr1: any[], _arr2: any[]): boolean {
+
+        if (!Array.isArray(_arr1) || !Array.isArray(_arr2) || _arr1.length !== _arr2.length)
+            return false;
+
+        var arr1 = _arr1.concat().sort();
+        var arr2 = _arr2.concat().sort();
+        for (var i = 0; i < arr1.length; i++) {
+
+            if (arr1[i] !== arr2[i])
+                return false;
+
         }
-
-        return matches;
+        return true;
     }
 }

--- a/src/app/services/match.service.ts
+++ b/src/app/services/match.service.ts
@@ -32,7 +32,7 @@ export class MatchService {
 
     public createMatch(match: Match) {
         var newMatch = match;
-        newMatch.id = null;
+        //newMatch.id = null;
         return this.matches.push(newMatch);
     }
 

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -23,11 +23,11 @@ import { Match } from "../models/match";
     }
 
     public getAllUsersForMatch(match: Match): User[] {
-        let filteredList: User[];
+        let filteredList: User[] = [];
 
         match.participants.forEach(participant => {
-            this.database.object(`${this.userTableName}/${participant.id}`).valueChanges().subscribe(result => {
-                filteredList.push(result as User);
+            this.database.object(`${this.userTableName}/${participant.id}`).snapshotChanges().subscribe(user => {
+                filteredList.push({ id: user.key, ...user.payload.val() } as User);
             });
         });
 
@@ -35,11 +35,11 @@ import { Match } from "../models/match";
     }
 
     public getAllUsersForCompetition(competition: Competition): User[] {
-        let filteredList: User[];
+        let filteredList: User[] = [];
 
         competition.participants.forEach(participant => {
-            this.database.object(`${this.userTableName}/${participant.id}`).valueChanges().subscribe(result => {
-                filteredList.push(result as User);
+            this.database.object(`${this.userTableName}/${participant.id}`).snapshotChanges().subscribe(user => {
+                filteredList.push({id: user.key, ...user.payload.val()} as User);
             });
         });
 


### PR DESCRIPTION
Verbeteringen in het Tournament generation mechanisme:
Nu is dit ook herbruikbaar voor het genereren van matches voor Poules. 
Het mechnisme is nog steeds niet 100% af: stel dat je 2 spelers hebt en 4 rondes dan moeten die 2 spelers meerdere keren tegen elkaar spelen. Nu kan dat nog niet.

Opzet Poule generatie mechanisme:
Grotendeels hetzelfde als het genereren van een Tournament.
Alleen kan het nog voorkomen dat een speler twee wedstrijden op dezelfde tijd speelt.

Beide mechanismes bevatten ook een schematische weergave die via de detail pagina te bereiken is.
Ook zijn bijhorende wijzigingen aan de forms gemaakt (dynamische extra velden per type competitie plus implementatie Dragula-ng module).